### PR TITLE
はみ出さないようにwidth:100%を追加、画像のレイアウトをflexからgridに変更

### DIFF
--- a/components/BannerItems.vue
+++ b/components/BannerItems.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
 .banner_items.flex-row.justify-center
   NLink.mg-right-16(to="/consultation")
-    img.banner_1(:src="require('@/assets/images/footer_banner_1.png')")
+    img.banner_1.width-100per(:src="require('@/assets/images/footer_banner_1.png')")
   NLink(to="/consultation#flower_item")
-    img.banner_2(:src="require('@/assets/images/footer_banner_2.png')")
+    img.banner_2.width-100per(:src="require('@/assets/images/footer_banner_2.png')")
 </template>
 
 <style lang="sass" scoped>

--- a/components/PageTopView.vue
+++ b/components/PageTopView.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-section.page_top
+section.page_top.width-100per
   .page_top_inner.mg-auto
     p.page_top_title {{ title }}
     p.page_top_caption.text-center {{ caption }}

--- a/pages/gallery.vue
+++ b/pages/gallery.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
 article.page_container
   PageTop(title="Gallery", caption="ギャラリー")
-  .page_content_wrap
+  .page_content_wrap.gallery_wrap
     .gallery
-      .gallery_flex
+      .gallery_grid
 
         picture.gallery_picture(v-for="index in 16" :key="index")
           source(:srcset="require('@/assets/images/gallery/gallery_' + index + '_sp.png')" media="(max-width: 600px)")
@@ -32,20 +32,25 @@ export default {
 </script>
 
 <style lang="sass" scoped>
+.gallery_wrap
+  max-width: 1000px
+  width: 100%
+
 .gallery
   padding: 0 80px
   background-color: #FFF7FA
 
-  &_flex
-   display: flex
-   flex-wrap: wrap;
-   transform: translateY(50px);
-
+  &_grid
+   display: grid
+   grid-template: '1  2  3  4  ' '5  6  7  8  ' '9  10 11 12' '13 14 15 16'
+   transform: translateY(50px)
+   
   &_picture
-    width: 210px
+    width: 100%
     > .gallery_img
       width: 100%
       height: 100%
       object-fit: cover
+      cursor: pointer
 
 </style>


### PR DESCRIPTION
はみ出していて横スクロールが発生していたので、PageTopViewとBannerItemsとgalleryにwidth:100%を追加しました。

galleryの画像のレイアウトを以前はdisplay:flexで指定していたのを、レスポンシブ対応のしやすさからgridに変更しました。

よろしくお願いします！